### PR TITLE
Fix bms_next_member

### DIFF
--- a/log_fdw.c
+++ b/log_fdw.c
@@ -770,8 +770,6 @@ check_selective_binary_conversion(RelOptInfo *baserel,
 #else	
 	while ((attnum = bms_first_member(attrs_used)) >= 0)
 	{
-	
-	
 		/* Adjust for system attributes. */
 		attnum += FirstLowInvalidHeapAttributeNumber;
 #endif


### PR DESCRIPTION

Description of changes:
Upstream removed bms_first_member. Changed code to use bms_next_member

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
