### PR TITLE
Ensure compatibility with PostgreSQL 17

### DIFF
--- a/log_fdw.c
+++ b/log_fdw.c
@@ -422,6 +422,9 @@ fileGetForeignPaths(PlannerInfo *root,
 									 NIL,	/* no pathkeys */
 									 baserel->lateral_relids,
 									 NULL,	/* no extra plan */
+#if (PG_VERSION_NUM >= 170000)
+									 NIL, /* no fdw_restrictinfo list */
+#endif
 									 coptions));
 
 	/*


### PR DESCRIPTION
postgres/postgres@9e9931d2bf introduced a feature into remote table scans that updated the interface on the `create_foreignscan_path` function, which requires updating to maintain compatibility with PostgreSQL 17. This can borrow the semantics used for file_fdw, referneced in the same commit, to return compatibility, as log_fdw doesn't need to leverage joins.

fixes #14