### PR TITLE
Compatibility commit for PostgreSQL 18

### DIFF
--- a/log_fdw.c
+++ b/log_fdw.c
@@ -417,6 +417,9 @@ fileGetForeignPaths(PlannerInfo *root,
 			 create_foreignscan_path(root, baserel,
 									 NULL,	/* default pathtarget */
 									 baserel->rows,
+#if (PG_VERSION_NUM >= 180000)
+									 0,
+#endif									 
 									 startup_cost,
 									 total_cost,
 									 NIL,	/* no pathkeys */


### PR DESCRIPTION
postgres/postgres@e222534679 included a new attribute for `create_foreignscan_path` for costing around the number of disabled nodes within a path. The corresponding change for `file_fdw` included setting the number of disabled nodes to `0`, so this commit directly incorporates that change.