### PR TITLE
Allow create_foreign_table_for_log_file to use IF NOT EXISTS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 MODULES = log_fdw
 
 EXTENSION = log_fdw
-DATA = log_fdw--1.4.sql
+DATA = log_fdw--1.4.sql log_fdw--1.4--1.5.sql
 PGFILEDESC = "log_fdw - foreign data wrapper for Postgres log files"
 
 REGRESS = log_fdw

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ CREATE EXTENSION
 ```
 postgres=# \df
                                                       List of functions
- Schema |               Name                | Result data type |                  Argument data types                  | Type 
---------+-----------------------------------+------------------+-------------------------------------------------------+------
- public | create_foreign_table_for_log_file | void             | table_name text, server_name text, log_file_name text | func
- public | list_postgres_log_files           | SETOF record     | OUT file_name text, OUT file_size_bytes bigint        | func
- public | log_fdw_handler                   | fdw_handler      |                                                       | func
- public | log_fdw_validator                 | void             | text[], oid                                           | func
-(4 rows)
+ Schema |               Name                | Result data type |                             Argument data types                              | Type 
+--------+-----------------------------------+------------------+------------------------------------------------------------------------------+------
+ public | create_foreign_table_for_log_file | void             | table_name text, server_name text, log_file_name text                        | func
+ public | create_foreign_table_for_log_file | void             | table_name text, server_name text, log_file_name text, if_not_exists boolean | func
+ public | list_postgres_log_files           | SETOF record     | OUT file_name text, OUT file_size_bytes bigint                               | func
+ public | log_fdw_handler                   | fdw_handler      |                                                                              | func
+ public | log_fdw_validator                 | void             | text[], oid                                                                  | func
+(5 rows)
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -38,10 +38,20 @@ Clone the repository from https://github.com/aws/postgresql-logfdw:
 ```
 git clone https://github.com/aws/postgresql-logfdw.git
 ``` 
-Run `make clean` and `make install` to install the extension. Remember to set
-`PATH` environment variable to point to `pg_config`. Alternatively, copy the
-extension source code to `contrib` directory under PostgreSQL source tree and
-install it.
+
+The extension can be installed in two different ways. As a stand alone project,
+first set the `PATH` environment variable to point to `pg_config`. Then run the
+following in the postgresql-logfdw directory:
+
+```
+export USE_PGXS=1
+make
+make install
+```
+
+Alternatively, if the extension needs to be part of a larger PostgreSQL 
+distrubution, the extension source code can be copied to the `contrib` directory
+under PostgreSQL source tree and installed from there.
 
 ## Usage
 

--- a/log_fdw--1.4--1.5.sql
+++ b/log_fdw--1.4--1.5.sql
@@ -1,0 +1,72 @@
+/* log_fdw--1.4--1.5 */
+
+/*
+ * Creates foreign table for a given server log file.
+ */
+CREATE OR REPLACE FUNCTION create_foreign_table_for_log_file(
+	table_name TEXT,
+	server_name TEXT,
+	log_file_name TEXT,
+	if_not_exists BOOL)
+RETURNS void AS
+$BODY$
+DECLARE
+	l_exists_str    text := '';
+BEGIN
+	IF if_not_exists
+	THEN
+		l_exists_str := 'IF NOT EXISTS';
+	END IF;
+
+	IF $3 LIKE '%.csv' or $3 LIKE '%.csv.gz'
+	THEN
+		EXECUTE format('CREATE FOREIGN TABLE %s %I (
+		  log_time			timestamp(3) with time zone,
+		  user_name			text,
+		  database_name			text,
+		  process_id			integer,
+		  connection_from		text,
+		  session_id			text,
+		  session_line_num		bigint,
+		  command_tag			text,
+		  session_start_time		timestamp with time zone,
+		  virtual_transaction_id	text,
+		  transaction_id		bigint,
+		  error_severity		text,
+		  sql_state_code		text,
+		  message			text,
+		  detail			text,
+		  hint				text,
+		  internal_query		text,
+		  internal_query_pos		integer,
+		  context			text,
+		  query				text,
+		  query_pos			integer,
+		  location			text,
+		  application_name		text,
+		  backend_type			text,
+		  leader_pid			integer,
+		  query_id			bigint
+		) SERVER %I
+		OPTIONS (filename %L)',
+		l_exists_str, $1, $2, $3);
+	ELSE
+		EXECUTE format('CREATE FOREIGN TABLE %s %I (
+		  log_entry text
+		) SERVER %I
+		OPTIONS (filename %L)',
+		l_exists_str, $1, $2, $3);
+	END IF;
+END
+$BODY$
+	LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION create_foreign_table_for_log_file(
+	table_name TEXT,
+	server_name TEXT,
+	log_file_name TEXT)
+ RETURNS void
+ LANGUAGE sql
+BEGIN ATOMIC
+	SELECT create_foreign_table_for_log_file(table_name, server_name, log_file_name, false);
+END;


### PR DESCRIPTION
Issue #17 , if available:

Description of changes:
Add an overloaded function for create_foreign_table_for_log_file to take a parameter to determine if IF NOT EXISTS should be used when creating a foreign table. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
